### PR TITLE
Traverse directory tree upwards to find function

### DIFF
--- a/Solutions/Corvus.Testing.AzureFunctions.SpecFlow.Demo/AzureFunctionsTesting/DemoFunctionPerFeatureHooks.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions.SpecFlow.Demo/AzureFunctionsTesting/DemoFunctionPerFeatureHooks.cs
@@ -4,10 +4,10 @@
 
 namespace Corvus.Testing.SpecFlow.Demo.AzureFunctionsTesting
 {
+    using System;
     using System.Threading.Tasks;
     using Corvus.Testing.AzureFunctions;
     using Corvus.Testing.AzureFunctions.SpecFlow;
-    using NUnit.Framework;
     using TechTalk.SpecFlow;
 
     [Binding]
@@ -20,7 +20,6 @@ namespace Corvus.Testing.SpecFlow.Demo.AzureFunctionsTesting
             FunctionConfiguration functionConfiguration = FunctionsBindings.GetFunctionConfiguration(featureContext);
 
             return functionsController.StartFunctionsInstance(
-                TestContext.CurrentContext.TestDirectory,
                 "Corvus.Testing.AzureFunctions.DemoFunction",
                 7075,
                 "netcoreapp3.1",

--- a/Solutions/Corvus.Testing.AzureFunctions.SpecFlow.Demo/AzureFunctionsTesting/DemoFunctionPerScenarioHooks.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions.SpecFlow.Demo/AzureFunctionsTesting/DemoFunctionPerScenarioHooks.cs
@@ -4,10 +4,10 @@
 
 namespace Corvus.Testing.SpecFlow.Demo.AzureFunctionsTesting
 {
+    using System;
     using System.Threading.Tasks;
     using Corvus.Testing.AzureFunctions;
     using Corvus.Testing.AzureFunctions.SpecFlow;
-    using NUnit.Framework;
     using TechTalk.SpecFlow;
 
     [Binding]
@@ -20,7 +20,6 @@ namespace Corvus.Testing.SpecFlow.Demo.AzureFunctionsTesting
             FunctionConfiguration functionConfiguration = FunctionsBindings.GetFunctionConfiguration(scenarioContext);
 
             return functionsController.StartFunctionsInstance(
-                TestContext.CurrentContext.TestDirectory,
                 "Corvus.Testing.AzureFunctions.DemoFunction",
                 7075,
                 "netcoreapp3.1",

--- a/Solutions/Corvus.Testing.AzureFunctions.SpecFlow/Corvus/Testing/AzureFunctions/SpecFlow/FunctionsBindings.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions.SpecFlow/Corvus/Testing/AzureFunctions/SpecFlow/FunctionsBindings.cs
@@ -4,6 +4,7 @@
 
 namespace Corvus.Testing.AzureFunctions.SpecFlow
 {
+    using System;
     using System.Threading.Tasks;
     using Corvus.Testing.AzureFunctions;
     using Corvus.Testing.SpecFlow;
@@ -77,7 +78,7 @@ namespace Corvus.Testing.AzureFunctions.SpecFlow
         public Task StartAFunctionsInstance(string path, int port)
         {
             return GetFunctionsController(this.scenarioContext)
-                .StartFunctionsInstance(TestContext.CurrentContext.TestDirectory, path, port, "netcoreapp3.1");
+                .StartFunctionsInstance(path, port, "netcoreapp3.1");
         }
 
         /// <summary>
@@ -92,13 +93,7 @@ namespace Corvus.Testing.AzureFunctions.SpecFlow
         {
             FunctionConfiguration configuration = FunctionsBindings.GetFunctionConfiguration(this.scenarioContext);
             return GetFunctionsController(this.scenarioContext)
-                .StartFunctionsInstance(
-                    TestContext.CurrentContext.TestDirectory,
-                    path,
-                    port,
-                    runtime,
-                    "csharp",
-                    configuration);
+                .StartFunctionsInstance(path, port, runtime, "csharp", configuration);
         }
 
         /// <summary>

--- a/Solutions/Corvus.Testing.AzureFunctions.Xunit.Demo/AzureFunctionFixture.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions.Xunit.Demo/AzureFunctionFixture.cs
@@ -26,7 +26,6 @@ namespace Corvus.Testing.AzureFunctions.Xunit.Demo
         public async Task InitializeAsync()
         {
             await this.function.StartFunctionsInstance(
-                Environment.CurrentDirectory,
                 "Corvus.Testing.AzureFunctions.DemoFunction",
                 this.Port,
                 "netcoreapp3.1");

--- a/Solutions/Corvus.Testing.AzureFunctions.Xunit.Demo/ConfiguredAzureFunctionFixture.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions.Xunit.Demo/ConfiguredAzureFunctionFixture.cs
@@ -22,7 +22,6 @@ namespace Corvus.Testing.AzureFunctions.Xunit.Demo
             configuration.EnvironmentVariables.Add("ResponseMessage", this.Greet("{name}"));
 
             await this.function.StartFunctionsInstance(
-                Environment.CurrentDirectory,
                 "Corvus.Testing.AzureFunctions.DemoFunction",
                 this.Port,
                 "netcoreapp3.1",

--- a/Solutions/Corvus.Testing.AzureFunctions.Xunit.Demo/FunctionPerTestFacts.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions.Xunit.Demo/FunctionPerTestFacts.cs
@@ -79,7 +79,6 @@ namespace Corvus.Testing.AzureFunctions.Xunit.Demo
         public async Task InitializeAsync()
         {
             await this.function.StartFunctionsInstance(
-                Environment.CurrentDirectory,
                 "Corvus.Testing.AzureFunctions.DemoFunction",
                 this.Port,
                 "netcoreapp3.1");

--- a/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionsController.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionsController.cs
@@ -18,7 +18,7 @@ namespace Corvus.Testing.AzureFunctions
     /// <remarks>
     /// <para>
     /// This class supports a limited degree of thread safety: you can have multiple calls to
-    /// <see cref="StartFunctionsInstance(string, string, int, string, string, FunctionConfiguration?)"/> in progress simultaneously for a single
+    /// <see cref="StartFunctionsInstance(string, int, string, string, FunctionConfiguration?)"/> in progress simultaneously for a single
     /// instance of this class, but <see cref="TeardownFunctions"/> must not be called concurrently
     /// with any other calls into this class. The intention is to enable tests to spin up multiple
     /// functions simultaneously. This is useful because function startup can be the dominant
@@ -35,8 +35,6 @@ namespace Corvus.Testing.AzureFunctions
         /// <summary>
         /// Start a functions instance.
         /// </summary>
-        /// <param name="testDirectory">The directory associated with the current test context,
-        /// usually available from your testing framework's context object(s).</param>
         /// <param name="path">The location of the functions project.</param>
         /// <param name="port">The port on which to start the functions instance.</param>
         /// <param name="runtime">The runtime version for use with the function host (e.g. netcoreapp3.1).</param>
@@ -44,14 +42,9 @@ namespace Corvus.Testing.AzureFunctions
         /// <param name="configuration">A <see cref="FunctionConfiguration"/> instance, for conveying
         /// configuration values via environment variables to the function host process.</param>
         /// <returns>A task that completes once the function instance has started.</returns>
-        public async Task StartFunctionsInstance(
-            string testDirectory,
-            string path,
-            int port,
-            string runtime,
-            string provider = "csharp",
-            FunctionConfiguration? configuration = null)
+        public async Task StartFunctionsInstance(string path, int port, string runtime, string provider = "csharp", FunctionConfiguration? configuration = null)
         {
+            string testDirectory = Environment.CurrentDirectory;
             Console.WriteLine($"Starting a function instance for project {path} on port {port}");
             Console.WriteLine("\tStarting process");
 

--- a/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionsController.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionsController.cs
@@ -44,7 +44,6 @@ namespace Corvus.Testing.AzureFunctions
         /// <returns>A task that completes once the function instance has started.</returns>
         public async Task StartFunctionsInstance(string path, int port, string runtime, string provider = "csharp", FunctionConfiguration? configuration = null)
         {
-            string testDirectory = Environment.CurrentDirectory;
             Console.WriteLine($"Starting a function instance for project {path} on port {port}");
             Console.WriteLine("\tStarting process");
 
@@ -52,7 +51,7 @@ namespace Corvus.Testing.AzureFunctions
                 port,
                 provider,
                 await GetToolPath(),
-                GetWorkingDirectory(testDirectory, path, runtime),
+                GetWorkingDirectory(path, runtime),
                 configuration);
 
             lock (this.sync)
@@ -236,8 +235,9 @@ namespace Corvus.Testing.AzureFunctions
             return processHandler.StandardOutputText.Trim();
         }
 
-        private static string GetWorkingDirectory(string currentTestDirectory, string path, string runtime)
+        private static string GetWorkingDirectory(string path, string runtime)
         {
+            string currentTestDirectory = Environment.CurrentDirectory;
             string directoryExtension = $"\\bin\\release\\{runtime}";
 
             string lowerInvariantCurrentDirectory = currentTestDirectory.ToLowerInvariant();

--- a/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionsController.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionsController.cs
@@ -237,20 +237,19 @@ namespace Corvus.Testing.AzureFunctions
 
         private static string GetWorkingDirectory(string path, string runtime)
         {
-            string currentTestDirectory = Environment.CurrentDirectory;
-            string directoryExtension = $"\\bin\\release\\{runtime}";
+            string currentDirectory = Environment.CurrentDirectory.ToLowerInvariant();
 
-            string lowerInvariantCurrentDirectory = currentTestDirectory.ToLowerInvariant();
-            if (lowerInvariantCurrentDirectory.Contains("debug"))
+            string directoryExtension = $"\\bin\\release\\{runtime}";
+            if (currentDirectory.Contains("debug"))
             {
                 directoryExtension = $"\\bin\\debug\\{runtime}";
             }
 
-            Console.WriteLine($"\tCurrent directory: {lowerInvariantCurrentDirectory}");
+            Console.WriteLine($"\tCurrent directory: {currentDirectory}");
 
-            string root = currentTestDirectory.Substring(
+            string root = currentDirectory.Substring(
                 0,
-                currentTestDirectory.IndexOf(@"\Solutions\") + 11);
+                currentDirectory.IndexOf(@"\solutions\") + 11);
 
             Console.WriteLine($"\tRoot: {root}");
             return root + path + directoryExtension;

--- a/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionsController.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionsController.cs
@@ -239,20 +239,31 @@ namespace Corvus.Testing.AzureFunctions
         {
             string currentDirectory = Environment.CurrentDirectory.ToLowerInvariant();
 
-            string directoryExtension = $"\\bin\\release\\{runtime}";
+            string directoryExtension = @$"bin\release\{runtime}";
             if (currentDirectory.Contains("debug"))
             {
-                directoryExtension = $"\\bin\\debug\\{runtime}";
+                directoryExtension = @$"bin\debug\{runtime}";
             }
 
             Console.WriteLine($"\tCurrent directory: {currentDirectory}");
 
-            string root = currentDirectory.Substring(
-                0,
-                currentDirectory.IndexOf(@"\solutions\") + 11);
+            var candidate = new DirectoryInfo(currentDirectory);
+            bool candidateIsSuccessful = false;
+
+            while (!candidateIsSuccessful && candidate.Parent != null)
+            {
+                // We can skip the current directory and go straight to its parent, as it will
+                // never be the directory we want.
+                candidate = candidate.Parent;
+
+                string pathToTest = Path.Combine(candidate.FullName, path, directoryExtension);
+                candidateIsSuccessful = Directory.Exists(pathToTest);
+            }
+
+            string root = candidate.FullName;
 
             Console.WriteLine($"\tRoot: {root}");
-            return root + path + directoryExtension;
+            return Path.Combine(root, path, directoryExtension);
         }
 
         private static FunctionOutputBufferHandler StartFunctionHostProcess(


### PR DESCRIPTION
Prior to this PR, `Corvus.Testing.AzureFunctions` required the Function project to live somewhere inside a directory called `Solutions`. This hard requirement meant the library could not be easily consumed from third-party projects. 

In this PR the library now traverses up the directory tree until it finds a repository that, when combined with the function name/path and build directory (e.g. `bin\Debug\netcoreapp3.1`), provides a valid path as verified by `Directory.Exists()`. That directory is then returned from the `GetWorkingDirectory()` helper function combined with the function name/path and build directory as before. I have verified that this change works with our own testing library as well as the tests for this project.

A nice side effect of #83 was that the `currentTestDirectory` parameter was no longer required: empirically, NUnit's `TestContext.CurrentContext.TestDirectory` is a utility accessor equivalent to `Environment.CurrentDirectory`. The change has been applied in this PR to make `StartFunctionsInstance()` a little easier to call, although this does represent a breaking change. 

Fixes #56.