### PR TITLE
Allow existing function instances to be used test runs

### DIFF
--- a/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionProject.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionProject.cs
@@ -1,0 +1,67 @@
+﻿// <copyright file="FunctionProject.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Corvus.Testing.AzureFunctions
+{
+    using System;
+    using System.IO;
+
+    /// <summary>
+    /// Utility methods for working with Azure Functions projects.
+    /// </summary>
+    public sealed class FunctionProject
+    {
+        /// <summary>
+        /// Resolves an Azure Functions project runtime directory from the given path fragment
+        /// and specified runtime.
+        /// </summary>
+        /// <example>
+        /// <![CDATA[
+        /// public async Task ReadFunctionConfiguration()
+        /// {
+        ///     string functionProjectPath = FunctionProject.ResolvePath(
+        ///         "Solutions/Corvus.Testing.AzureFunctions.DemoFunction",
+        ///         "netcoreapp3.1");
+        ///
+        ///     string projectSettingsFile = Path.Combine(functionProjectPath, "local.settings.json");
+        /// }
+        /// ]]>
+        /// </example>
+        /// <param name="pathFragment">The path to the Azure Functions project, relative to some
+        /// common root folder.</param>
+        /// <param name="runtime">The runtime targeted by the Azure Functions project.</param>
+        /// <returns>A string containing the full path to the Azure Functions project runtime
+        /// directory.</returns>
+        public static string ResolvePath(string pathFragment, string runtime)
+        {
+            string currentDirectory = Environment.CurrentDirectory.ToLowerInvariant();
+
+            string directoryExtension = @$"bin\release\{runtime}";
+            if (currentDirectory.Contains("debug"))
+            {
+                directoryExtension = @$"bin\debug\{runtime}";
+            }
+
+            Console.WriteLine($"\tCurrent directory: {currentDirectory}");
+
+            var candidate = new DirectoryInfo(currentDirectory);
+            bool candidateIsSuccessful = false;
+
+            while (!candidateIsSuccessful && candidate.Parent != null)
+            {
+                // We can skip the current directory and go straight to its parent, as it will
+                // never be the directory we want.
+                candidate = candidate.Parent;
+
+                string pathToTest = Path.Combine(candidate.FullName, pathFragment, directoryExtension);
+                candidateIsSuccessful = Directory.Exists(pathToTest);
+            }
+
+            string root = candidate.FullName;
+
+            Console.WriteLine($"\tRoot: {root}");
+            return Path.Combine(root, pathFragment, directoryExtension);
+        }
+    }
+}

--- a/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionsController.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionsController.cs
@@ -56,10 +56,9 @@ namespace Corvus.Testing.AzureFunctions
             Console.WriteLine($"Starting a function instance for project {path} on port {port}");
             Console.WriteLine("\tStarting process");
 
-            FunctionOutputBufferHandler bufferHandler = StartFunctionHostProcess(
+            FunctionOutputBufferHandler bufferHandler = await StartFunctionHostProcess(
                 port,
                 provider,
-                await GetToolPath(),
                 FunctionProject.ResolvePath(path, runtime),
                 configuration);
 
@@ -252,14 +251,15 @@ namespace Corvus.Testing.AzureFunctions
                 .Any(e => e.Port == port);
         }
 
-        private static FunctionOutputBufferHandler StartFunctionHostProcess(
+        private static async Task<FunctionOutputBufferHandler> StartFunctionHostProcess(
             int port,
             string provider,
-            string toolPath,
             string workingDirectory,
             FunctionConfiguration? functionConfiguration)
         {
-            var startInfo = new ProcessStartInfo(toolPath, $"host start --port {port} --{provider}")
+            var startInfo = new ProcessStartInfo(
+                await GetToolPath(),
+                $"host start --port {port} --{provider}")
             {
                 WorkingDirectory = workingDirectory,
                 UseShellExecute = false,

--- a/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionsController.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionsController.cs
@@ -60,7 +60,7 @@ namespace Corvus.Testing.AzureFunctions
                 port,
                 provider,
                 await GetToolPath(),
-                GetWorkingDirectory(path, runtime),
+                FunctionProject.ResolvePath(path, runtime),
                 configuration);
 
             lock (this.sync)
@@ -242,37 +242,6 @@ namespace Corvus.Testing.AzureFunctions
             // We get a newline character on the end of the standard output, so we need to
             // trim before returning.
             return processHandler.StandardOutputText.Trim();
-        }
-
-        private static string GetWorkingDirectory(string path, string runtime)
-        {
-            string currentDirectory = Environment.CurrentDirectory.ToLowerInvariant();
-
-            string directoryExtension = @$"bin\release\{runtime}";
-            if (currentDirectory.Contains("debug"))
-            {
-                directoryExtension = @$"bin\debug\{runtime}";
-            }
-
-            Console.WriteLine($"\tCurrent directory: {currentDirectory}");
-
-            var candidate = new DirectoryInfo(currentDirectory);
-            bool candidateIsSuccessful = false;
-
-            while (!candidateIsSuccessful && candidate.Parent != null)
-            {
-                // We can skip the current directory and go straight to its parent, as it will
-                // never be the directory we want.
-                candidate = candidate.Parent;
-
-                string pathToTest = Path.Combine(candidate.FullName, path, directoryExtension);
-                candidateIsSuccessful = Directory.Exists(pathToTest);
-            }
-
-            string root = candidate.FullName;
-
-            Console.WriteLine($"\tRoot: {root}");
-            return Path.Combine(root, path, directoryExtension);
         }
 
         private static bool IsSomethingAlreadyListeningOn(int port)


### PR DESCRIPTION
If there's already a process listening on the port requested for the tests, then reuse that process for the test run. This is useful for debugging failures in the function itself, where the tests can be run from the command-line (remembering to include the --no-build flag) against a Function instance running in Visual Studio with the debugger attached.

We now print a warning indicating the test may produce unexpected result (e.g. if the process dies mid-run, is a build from a different branch, etc.). With the function process no longer under the control of the test process, it's much more likely the test will fail for spurious reasons.

I've also extracted and renamed the `GetWorkingDirectory()` function so that it can be called from outside the library. This is "good enough" for tidying up our integration with Corvus.Testing, although a better solution would be to parse the `local.settings.json` and provide it via some appropriate interface (e.g., `IDictionary`, `IConfiguration`). 

It occurs to me that the only tests that exist here for the Azure Functions library are the demo tests under SpecFlow and Xunit. Maybe this is ok...

Fixes #96. 