### PR TITLE
Write output to an ILogger instead of Console

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -27,6 +27,9 @@ jobs:
   auto_merge:
     name: Auto-squash the PR
     runs-on: ubuntu-18.04
+    # Don't process PRs from forked repos
+    if:
+      github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Generate token
         id: generate_token

--- a/Solutions/Corvus.Testing.AzureFunctions.DemoFunction/Corvus.Testing.AzureFunctions.DemoFunction.csproj
+++ b/Solutions/Corvus.Testing.AzureFunctions.DemoFunction/Corvus.Testing.AzureFunctions.DemoFunction.csproj
@@ -12,7 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.1" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.6" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/Solutions/Corvus.Testing.AzureFunctions.SpecFlow.Demo/AzureFunctionsTesting/DemoFunctionPerFeatureHooks.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions.SpecFlow.Demo/AzureFunctionsTesting/DemoFunctionPerFeatureHooks.cs
@@ -8,6 +8,7 @@ namespace Corvus.Testing.SpecFlow.Demo.AzureFunctionsTesting
     using System.Threading.Tasks;
     using Corvus.Testing.AzureFunctions;
     using Corvus.Testing.AzureFunctions.SpecFlow;
+    using Microsoft.Extensions.Logging;
     using TechTalk.SpecFlow;
 
     [Binding]
@@ -39,7 +40,7 @@ namespace Corvus.Testing.SpecFlow.Demo.AzureFunctionsTesting
         public static void WriteOutput(FeatureContext featureContext)
         {
             FunctionsController functionsController = FunctionsBindings.GetFunctionsController(featureContext);
-            functionsController.GetFunctionsOutput().WriteAllToConsoleAndClear();
+            featureContext.Get<ILogger>().LogAllAndClear(functionsController.GetFunctionsOutput());
         }
 
         [AfterFeature("usingDemoFunctionPerFeature", "usingDemoFunctionPerFeatureWithAdditionalConfiguration")]

--- a/Solutions/Corvus.Testing.AzureFunctions.SpecFlow/Corvus.Testing.AzureFunctions.SpecFlow.csproj
+++ b/Solutions/Corvus.Testing.AzureFunctions.SpecFlow/Corvus.Testing.AzureFunctions.SpecFlow.csproj
@@ -22,6 +22,7 @@
     </PackageReference>
     <PackageReference Include="SpecFlow" Version="3.3.57" />
     <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Solutions/Corvus.Testing.AzureFunctions.SpecFlow/Corvus/Testing/AzureFunctions/SpecFlow/FunctionsBindings.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions.SpecFlow/Corvus/Testing/AzureFunctions/SpecFlow/FunctionsBindings.cs
@@ -4,11 +4,10 @@
 
 namespace Corvus.Testing.AzureFunctions.SpecFlow
 {
-    using System;
     using System.Threading.Tasks;
     using Corvus.Testing.AzureFunctions;
     using Corvus.Testing.SpecFlow;
-    using NUnit.Framework;
+    using Microsoft.Extensions.Logging;
     using TechTalk.SpecFlow;
 
     /// <summary>
@@ -18,6 +17,8 @@ namespace Corvus.Testing.AzureFunctions.SpecFlow
     public class FunctionsBindings
     {
         private readonly ScenarioContext scenarioContext;
+
+        private static readonly ILoggerFactory Log = LoggerFactory.Create(builder => builder.AddConsole());
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FunctionsBindings"/> class.
@@ -41,7 +42,7 @@ namespace Corvus.Testing.AzureFunctions.SpecFlow
         {
             if (!context.TryGetValue(out FunctionsController controller))
             {
-                controller = new FunctionsController();
+                controller = new FunctionsController(Log.CreateLogger<FunctionsController>());
                 context.Set(controller);
             }
 

--- a/Solutions/Corvus.Testing.AzureFunctions.SpecFlow/Corvus/Testing/AzureFunctions/SpecFlow/FunctionsBindings.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions.SpecFlow/Corvus/Testing/AzureFunctions/SpecFlow/FunctionsBindings.cs
@@ -40,9 +40,15 @@ namespace Corvus.Testing.AzureFunctions.SpecFlow
         /// </remarks>
         public static FunctionsController GetFunctionsController(SpecFlowContext context)
         {
+            if (!context.TryGetValue(out ILogger logger))
+            {
+                logger = Log.CreateLogger<FunctionsController>();
+                context.Set(logger);
+            }
+
             if (!context.TryGetValue(out FunctionsController controller))
             {
-                controller = new FunctionsController(Log.CreateLogger<FunctionsController>());
+                controller = new FunctionsController(logger);
                 context.Set(controller);
             }
 

--- a/Solutions/Corvus.Testing.AzureFunctions.Xunit.Demo/AzureFunctionFixture.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions.Xunit.Demo/AzureFunctionFixture.cs
@@ -4,9 +4,12 @@
 
 namespace Corvus.Testing.AzureFunctions.Xunit.Demo
 {
-    using System;
     using System.Threading.Tasks;
     using global::Xunit;
+    using global::Xunit.Abstractions;
+    using Microsoft.Extensions.Logging;
+    using Serilog;
+    using ILogger = Microsoft.Extensions.Logging.ILogger;
 
     /// <summary>
     /// Adapter class for Xunit.net to set up the Functions host process before all tests run, and tear it down only
@@ -16,9 +19,18 @@ namespace Corvus.Testing.AzureFunctions.Xunit.Demo
     {
         private readonly FunctionsController function;
 
-        public AzureFunctionFixture()
+        public AzureFunctionFixture(IMessageSink output)
         {
-            this.function = new FunctionsController();
+            ILogger logger = new LoggerFactory()
+                .AddSerilog(
+                    new LoggerConfiguration()
+                        .WriteTo.File(@$"C:\temp\{this.GetType().FullName}.log")
+                        .WriteTo.TestOutput(output)
+                        .MinimumLevel.Debug()
+                        .CreateLogger())
+                .CreateLogger("Xunit Demo tests");
+
+            this.function = new FunctionsController(logger);
         }
 
         public int Port => 7076;

--- a/Solutions/Corvus.Testing.AzureFunctions.Xunit.Demo/ConfiguredAzureFunctionFixture.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions.Xunit.Demo/ConfiguredAzureFunctionFixture.cs
@@ -4,13 +4,30 @@
 
 namespace Corvus.Testing.AzureFunctions.Xunit.Demo
 {
-    using System;
     using System.Threading.Tasks;
     using global::Xunit;
+    using global::Xunit.Abstractions;
+    using Microsoft.Extensions.Logging;
+    using Serilog;
+    using ILogger = Microsoft.Extensions.Logging.ILogger;
 
     public class ConfiguredAzureFunctionFixture : IAsyncLifetime
     {
-        private readonly FunctionsController function = new FunctionsController();
+        private readonly FunctionsController function;
+
+        public ConfiguredAzureFunctionFixture(IMessageSink output)
+        {
+            ILogger logger = new LoggerFactory()
+                .AddSerilog(
+                    new LoggerConfiguration()
+                        .WriteTo.File(@$"C:\temp\{this.GetType().FullName}.log")
+                        .WriteTo.TestOutput(output)
+                        .MinimumLevel.Debug()
+                        .CreateLogger())
+                .CreateLogger("Xunit Demo tests");
+
+            this.function = new FunctionsController(logger);
+        }
 
         public int Port => 7077;
 

--- a/Solutions/Corvus.Testing.AzureFunctions.Xunit.Demo/Corvus.Testing.AzureFunctions.Xunit.Demo.csproj
+++ b/Solutions/Corvus.Testing.AzureFunctions.Xunit.Demo/Corvus.Testing.AzureFunctions.Xunit.Demo.csproj
@@ -20,7 +20,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
+    <PackageReference Include="Serilog.Sinks.XUnit" Version="2.0.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
@@ -30,6 +34,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Corvus.Testing.AzureFunctions\Corvus.Testing.AzureFunctions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/Solutions/Corvus.Testing.AzureFunctions.Xunit.Demo/Corvus.Testing.AzureFunctions.Xunit.Demo.csproj
+++ b/Solutions/Corvus.Testing.AzureFunctions.Xunit.Demo/Corvus.Testing.AzureFunctions.Xunit.Demo.csproj
@@ -20,7 +20,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />

--- a/Solutions/Corvus.Testing.AzureFunctions.Xunit.Demo/xunit.runner.json
+++ b/Solutions/Corvus.Testing.AzureFunctions.Xunit.Demo/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "diagnosticMessages": false
+}

--- a/Solutions/Corvus.Testing.AzureFunctions/Corvus.Testing.AzureFunctions.csproj
+++ b/Solutions/Corvus.Testing.AzureFunctions/Corvus.Testing.AzureFunctions.csproj
@@ -22,6 +22,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.4" />
     <PackageReference Include="System.Management" Version="4.7.0" />
   </ItemGroup>
 </Project>

--- a/Solutions/Corvus.Testing.AzureFunctions/Corvus.Testing.AzureFunctions.csproj
+++ b/Solutions/Corvus.Testing.AzureFunctions/Corvus.Testing.AzureFunctions.csproj
@@ -22,7 +22,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.5" />
     <PackageReference Include="System.Management" Version="4.7.0" />
   </ItemGroup>
 </Project>

--- a/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionsController.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionsController.cs
@@ -75,7 +75,7 @@ namespace Corvus.Testing.AzureFunctions
             FunctionOutputBufferHandler bufferHandler = await StartFunctionHostProcess(
                 port,
                 provider,
-                FunctionProject.ResolvePath(path, runtime),
+                FunctionProject.ResolvePath(path, runtime, this.logger),
                 configuration);
 
             lock (this.sync)

--- a/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionsController.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionsController.cs
@@ -42,11 +42,18 @@ namespace Corvus.Testing.AzureFunctions
         /// <summary>
         /// Instantiates an object for starting and stopping instances of Azure Functions.
         /// </summary>
-        /// <param name="logger">An optional <see cref="ILogger"/>. If none is specified, messages
-        /// are written to the <see cref="NullLogger" />.</param>
-        public FunctionsController(ILogger? logger = null)
+        /// <remarks>
+        /// <para>
+        /// The <see cref="ILogger" /> argument can be provided using <c>Microsoft.Extensions.Logging.LoggerFactory.Create()</c>
+        /// and <see cref="ILoggerFactory.CreateLogger(string)"/>. This allows you to easily configure
+        /// logging as you would within an ASP.NET Core app, using an <c>Microsoft.Extensions.Logging.ILoggingBuilder</c> instance
+        /// and the usual extension methods like <c>AddDebug()</c> and <c>AddConsole()</c>.
+        /// </para>
+        /// </remarks>
+        /// <param name="logger">An <see cref="ILogger"/> destination for useful output messages.</param>
+        public FunctionsController(ILogger logger)
         {
-            this.logger = logger ?? NullLogger.Instance;
+            this.logger = logger;
         }
 
         /// <summary>

--- a/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionsController.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionsController.cs
@@ -13,6 +13,8 @@ namespace Corvus.Testing.AzureFunctions
     using System.Net.NetworkInformation;
     using System.Threading.Tasks;
     using Corvus.Testing.AzureFunctions.Internal;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
 
     /// <summary>
     /// Starts, manages and terminates functions instances for testing purposes.
@@ -34,6 +36,19 @@ namespace Corvus.Testing.AzureFunctions
         private readonly List<FunctionOutputBufferHandler> output = new List<FunctionOutputBufferHandler>();
         private readonly object sync = new object();
 
+        private readonly ILogger logger;
+        private IDisposable? functionLogScope;
+
+        /// <summary>
+        /// Instantiates an object for starting and stopping instances of Azure Functions.
+        /// </summary>
+        /// <param name="logger">An optional <see cref="ILogger"/>. If none is specified, messages
+        /// are written to the <see cref="NullLogger" />.</param>
+        public FunctionsController(ILogger? logger = null)
+        {
+            this.logger = logger ?? NullLogger.Instance;
+        }
+
         /// <summary>
         /// Start a functions instance.
         /// </summary>
@@ -46,15 +61,16 @@ namespace Corvus.Testing.AzureFunctions
         /// <returns>A task that completes once the function instance has started.</returns>
         public async Task StartFunctionsInstance(string path, int port, string runtime, string provider = "csharp", FunctionConfiguration? configuration = null)
         {
+            this.functionLogScope = this.logger.BeginScope(this);
             if (IsSomethingAlreadyListeningOn(port))
             {
-                Console.WriteLine($"Found a process listening on {port}. Is this a debug instance?");
-                Console.WriteLine("This test run will reuse this process, and so may produce unexpected results.");
+                this.logger.LogWarning("Found a process listening on {Port}. Is this a debug instance?", port);
+                this.logger.LogWarning("This test run will reuse this process, and so may produce unexpected results.");
                 return;
             }
 
-            Console.WriteLine($"Starting a function instance for project {path} on port {port}");
-            Console.WriteLine("\tStarting process");
+            this.logger.LogInformation("Starting a function instance for project {Path} on port {Port}", path, port);
+            this.logger.LogDebug("Starting process");
 
             FunctionOutputBufferHandler bufferHandler = await StartFunctionHostProcess(
                 port,
@@ -67,7 +83,7 @@ namespace Corvus.Testing.AzureFunctions
                 this.output.Add(bufferHandler);
             }
 
-            Console.WriteLine("\tProcess started; waiting for initialisation to complete");
+            this.logger.LogDebug("Process started; waiting for initialisation to complete");
 
             await Task.WhenAny(
                 bufferHandler.JobHostStarted,
@@ -77,6 +93,7 @@ namespace Corvus.Testing.AzureFunctions
             if (bufferHandler.ExitCode.IsCompleted)
             {
                 int exitCode = await bufferHandler.ExitCode.ConfigureAwait(false);
+                this.logger.LogError(bufferHandler.StandardErrorText);
                 throw new FunctionStartupException(
                     $"Function host process terminated unexpectedly with exit code {exitCode}.",
                     stderr: bufferHandler.StandardErrorText);
@@ -87,8 +104,8 @@ namespace Corvus.Testing.AzureFunctions
                 throw new FunctionStartupException("Timed out while starting functions instance.");
             }
 
-            Console.WriteLine();
-            Console.WriteLine("\tStarted");
+            this.logger.LogDebug("Initialisation completed");
+            this.logger.LogInformation("Function {Path} now running on port {Port}", path, port);
         }
 
         /// <summary>
@@ -120,7 +137,8 @@ namespace Corvus.Testing.AzureFunctions
                 }
             }
 
-            this.output.WriteAllToConsoleAndClear();
+            this.logger.LogAllAndClear(this.output);
+            this.functionLogScope?.Dispose();
 
             if (aggregate.Count > 0)
             {

--- a/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionsController.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionsController.cs
@@ -93,9 +93,17 @@ namespace Corvus.Testing.AzureFunctions
             if (bufferHandler.ExitCode.IsCompleted)
             {
                 int exitCode = await bufferHandler.ExitCode.ConfigureAwait(false);
-                this.logger.LogError(bufferHandler.StandardErrorText);
+                this.logger.LogError(
+                    @"Failed to start function host, process terminated unexpectedly with exit code {ExitCode}.
+StdOut: {StdOut}
+StdErr: {StdErr}",
+                    exitCode,
+                    bufferHandler.StandardOutputText,
+                    bufferHandler.StandardErrorText);
+
                 throw new FunctionStartupException(
                     $"Function host process terminated unexpectedly with exit code {exitCode}.",
+                    stdout: bufferHandler.StandardOutputText,
                     stderr: bufferHandler.StandardErrorText);
             }
 

--- a/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/Internal/ProcessOutputHandler.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/Internal/ProcessOutputHandler.cs
@@ -8,6 +8,8 @@ namespace Corvus.Testing.AzureFunctions.Internal
     using System.Diagnostics;
     using System.Text;
     using System.Threading.Tasks;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
 
     /// <summary>
     ///     Provides simplified access to a process's text output.
@@ -30,6 +32,8 @@ namespace Corvus.Testing.AzureFunctions.Internal
         /// </summary>
         private readonly StringBuilder standardError = new StringBuilder();
 
+        private readonly ILogger logger;
+
         /// <summary>
         ///     Initializes a new instance of the <see cref="ProcessOutputHandler"/> class for the
         ///     specified process, starting the process with the specified start info.
@@ -37,9 +41,15 @@ namespace Corvus.Testing.AzureFunctions.Internal
         /// <param name="startInfo">
         ///     The start information with which to launch the process.
         /// </param>
-        public ProcessOutputHandler(ProcessStartInfo startInfo)
+        /// <param name="logger">
+        ///     Optionally, a <see cref="Microsoft.Extensions.Logging.ILogger"/> implementation for
+        ///     writing output.
+        /// </param>
+        public ProcessOutputHandler(ProcessStartInfo startInfo, ILogger? logger = null)
         {
             this.Process = new Process { StartInfo = startInfo };
+
+            this.logger = logger ?? NullLogger.Instance;
 
             this.Process.Exited += this.OnProcessExit;
             this.Process.OutputDataReceived += this.OnOutputDataReceived;
@@ -164,6 +174,7 @@ namespace Corvus.Testing.AzureFunctions.Internal
                 this.standardOutput.AppendLine(e.Data);
             }
 
+            this.logger.LogDebug(e.Data);
             this.OnStandardOutputLine(e.Data);
         }
 
@@ -176,6 +187,7 @@ namespace Corvus.Testing.AzureFunctions.Internal
                 this.standardError.AppendLine(line);
             }
 
+            this.logger.LogWarning(line);
             this.OnStandardErrorLine(line);
         }
 

--- a/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/ProcessOutputExtensions.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/ProcessOutputExtensions.cs
@@ -6,6 +6,8 @@ namespace Corvus.Testing.AzureFunctions
 {
     using System;
     using System.Collections.Generic;
+    using System.IO;
+    using Microsoft.Extensions.Logging;
 
     /// <summary>
     /// Extension methods for the <see cref="IProcessOutput"/> interface.
@@ -13,41 +15,96 @@ namespace Corvus.Testing.AzureFunctions
     public static class ProcessOutputExtensions
     {
         /// <summary>
-        /// Writes the process StdOut and StdErr to the console, then clears both output buffers.
+        /// Writes the process StdOut and StdErr to the destination, then clears both output buffers.
         /// </summary>
         /// <param name="output">The <see cref="IProcessOutput"/> to write.</param>
         public static void WriteToConsoleAndClear(this IProcessOutput output)
         {
+            output.WriteAndClear(Console.Out);
+        }
+
+        /// <summary>
+        /// Writes the process StdOut and StdErr to the destination, then clears both output buffers.
+        /// </summary>
+        /// <param name="output">The <see cref="IProcessOutput"/> to write.</param>
+        /// <param name="destination">The destination <see cref="TextWriter"/>, e.g. <see cref="Console.Out"/>.</param>
+        public static void WriteAndClear(this IProcessOutput output, TextWriter destination)
+        {
             string name =
                 $"{output.ProcessStartInfo.FileName} {output.ProcessStartInfo.Arguments}, working directory {output.ProcessStartInfo.WorkingDirectory}";
 
-            Console.WriteLine($"\nStdOut for process {name}:");
-            Console.WriteLine(output.StandardOutputText);
-            Console.WriteLine();
+            destination.WriteLine($"\nStdOut for process {name}:");
+            destination.WriteLine(output.StandardOutputText);
+            destination.WriteLine();
 
             string stdErr = output.StandardErrorText;
-
             if (!string.IsNullOrEmpty(stdErr))
             {
-                Console.WriteLine($"\nStdErr for process {name}:");
-                Console.WriteLine(stdErr);
-                Console.WriteLine();
+                destination.WriteLine($"\nStdErr for process {name}:");
+                destination.WriteLine(output.StandardErrorText);
+                destination.WriteLine();
             }
 
             output.ClearAllOutput();
         }
 
         /// <summary>
-        /// Writes the process StdOut and StdErr to the console, then clears both output buffers for each supplied
+        /// Writes the process StdOut and StdErr to the destination, then clears both output buffers for each supplied
         /// <see cref="IProcessOutput"/>.
         /// </summary>
         /// <param name="outputs">The list of <see cref="IProcessOutput"/> to write.</param>
         public static void WriteAllToConsoleAndClear(this IEnumerable<IProcessOutput> outputs)
         {
+            outputs.WriteAllAndClear(Console.Out);
+        }
+
+        /// <summary>
+        /// Writes the process StdOut and StdErr to the destination, then clears both output buffers for each supplied
+        /// <see cref="IProcessOutput"/>.
+        /// </summary>
+        /// <param name="outputs">The list of <see cref="IProcessOutput"/> to write.</param>
+        /// <param name="destination">The destination <see cref="TextWriter"/>, e.g. <see cref="Console.Out"/>.</param>
+        public static void WriteAllAndClear(this IEnumerable<IProcessOutput> outputs, TextWriter destination)
+        {
             foreach (IProcessOutput output in outputs)
             {
-                output.WriteToConsoleAndClear();
+                output.WriteAndClear(destination);
             }
+        }
+
+        /// <summary>
+        /// Logs the process StdOut and StdErr to the destination, then clears both output buffers for each supplied
+        /// <see cref="IProcessOutput"/>.
+        /// </summary>
+        /// <param name="logger">The logger to write to.</param>
+        /// <param name="outputs">The list of <see cref="IProcessOutput"/> to write.</param>
+        public static void LogAllAndClear(this ILogger logger, IEnumerable<IProcessOutput> outputs)
+        {
+            foreach (IProcessOutput output in outputs)
+            {
+                logger.LogAndClear(output);
+            }
+        }
+
+        /// <summary>
+        /// Logs the process StdOut and StdErr to the destination, then clears both output buffers.
+        /// </summary>
+        /// <param name="logger">The logger to write to.</param>
+        /// <param name="output">The <see cref="IProcessOutput"/> to write.</param>
+        public static void LogAndClear(this ILogger logger, IProcessOutput output)
+        {
+            string name =
+                $"{output.ProcessStartInfo.FileName} {output.ProcessStartInfo.Arguments}, working directory {output.ProcessStartInfo.WorkingDirectory}";
+
+            logger.LogInformation("StdOut for process {Name}: {StdOut}", name, output.StandardOutputText);
+
+            string stdErr = output.StandardErrorText;
+            if (!string.IsNullOrEmpty(stdErr))
+            {
+                logger.LogWarning("StdErr for process {Name}: {StdErr}", name, stdErr);
+            }
+
+            output.ClearAllOutput();
         }
     }
 }

--- a/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/ProcessOutputExtensions.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/ProcessOutputExtensions.cs
@@ -15,64 +15,6 @@ namespace Corvus.Testing.AzureFunctions
     public static class ProcessOutputExtensions
     {
         /// <summary>
-        /// Writes the process StdOut and StdErr to the destination, then clears both output buffers.
-        /// </summary>
-        /// <param name="output">The <see cref="IProcessOutput"/> to write.</param>
-        public static void WriteToConsoleAndClear(this IProcessOutput output)
-        {
-            output.WriteAndClear(Console.Out);
-        }
-
-        /// <summary>
-        /// Writes the process StdOut and StdErr to the destination, then clears both output buffers.
-        /// </summary>
-        /// <param name="output">The <see cref="IProcessOutput"/> to write.</param>
-        /// <param name="destination">The destination <see cref="TextWriter"/>, e.g. <see cref="Console.Out"/>.</param>
-        public static void WriteAndClear(this IProcessOutput output, TextWriter destination)
-        {
-            string name =
-                $"{output.ProcessStartInfo.FileName} {output.ProcessStartInfo.Arguments}, working directory {output.ProcessStartInfo.WorkingDirectory}";
-
-            destination.WriteLine($"\nStdOut for process {name}:");
-            destination.WriteLine(output.StandardOutputText);
-            destination.WriteLine();
-
-            string stdErr = output.StandardErrorText;
-            if (!string.IsNullOrEmpty(stdErr))
-            {
-                destination.WriteLine($"\nStdErr for process {name}:");
-                destination.WriteLine(output.StandardErrorText);
-                destination.WriteLine();
-            }
-
-            output.ClearAllOutput();
-        }
-
-        /// <summary>
-        /// Writes the process StdOut and StdErr to the destination, then clears both output buffers for each supplied
-        /// <see cref="IProcessOutput"/>.
-        /// </summary>
-        /// <param name="outputs">The list of <see cref="IProcessOutput"/> to write.</param>
-        public static void WriteAllToConsoleAndClear(this IEnumerable<IProcessOutput> outputs)
-        {
-            outputs.WriteAllAndClear(Console.Out);
-        }
-
-        /// <summary>
-        /// Writes the process StdOut and StdErr to the destination, then clears both output buffers for each supplied
-        /// <see cref="IProcessOutput"/>.
-        /// </summary>
-        /// <param name="outputs">The list of <see cref="IProcessOutput"/> to write.</param>
-        /// <param name="destination">The destination <see cref="TextWriter"/>, e.g. <see cref="Console.Out"/>.</param>
-        public static void WriteAllAndClear(this IEnumerable<IProcessOutput> outputs, TextWriter destination)
-        {
-            foreach (IProcessOutput output in outputs)
-            {
-                output.WriteAndClear(destination);
-            }
-        }
-
-        /// <summary>
         /// Logs the process StdOut and StdErr to the destination, then clears both output buffers for each supplied
         /// <see cref="IProcessOutput"/>.
         /// </summary>


### PR DESCRIPTION
This PR replaces the existing `Console.WriteLine()` statements with equivalent lines writing to a `Microsoft.Extensions.Logging.ILogger`. Sadly, this introduces a breaking change: **`FunctionsController` requires an `ILogger` to be provided.** My initial position was to avoid the breaking change and support Console-by-default, but the `ILogger` interface is sufficiently tricky to implement that even a naive console logger proved pointless. I considered using the Microsoft-supplied console logger by default, but this made the dependencies of the library weightier than I wanted.

As previously, there are two examples of providing a logger to the `FunctionsController`, one in the SpecFlow bindings (using the Microsoft console logger) and one in the Xunit Demo project (using Serilog). Both use the same technique of instantiating a `LoggerFactory` and registering the desired providers with that factory instance, just as ASP.NET Core does under the covers.

Fixes #95.