### PR TITLE
Added SpecFlow dependencies to the pr-autoflow config

### DIFF
--- a/.github/config/pr-autoflow.json
+++ b/.github/config/pr-autoflow.json
@@ -1,4 +1,4 @@
 {
-  "AUTO_MERGE_PACKAGE_WILDCARD_EXPRESSIONS": "[\"Endjin.*\", \"Corvus.*\"]",
-  "AUTO_RELEASE_PACKAGE_WILDCARD_EXPRESSIONS": "[\"Corvus.*\"]"
+  "AUTO_MERGE_PACKAGE_WILDCARD_EXPRESSIONS": "[\"Endjin.*\", \"Corvus.*\", \"SpecFlow.*\"]",
+  "AUTO_RELEASE_PACKAGE_WILDCARD_EXPRESSIONS": "[\"Corvus.*\", \"SpecFlow.*\"]"
 }


### PR DESCRIPTION
In order to kickstart the cascading update of our SpecFlow meta package we need to include the SpecFlow packages in the auto merge/release config.

resolves #155 