### PR TITLE
Fix to function startup detection

### DIFF
--- a/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionsController.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionsController.cs
@@ -60,7 +60,7 @@ namespace Corvus.Testing.AzureFunctions
                 port,
                 provider,
                 FunctionProject.ResolvePath(path, runtime),
-                configuration);
+                configuration).ConfigureAwait(false);
 
             lock (this.sync)
             {
@@ -258,7 +258,7 @@ namespace Corvus.Testing.AzureFunctions
             FunctionConfiguration? functionConfiguration)
         {
             var startInfo = new ProcessStartInfo(
-                await GetToolPath(),
+                await GetToolPath().ConfigureAwait(false),
                 $"host start --port {port} --{provider}")
             {
                 WorkingDirectory = workingDirectory,
@@ -277,6 +277,10 @@ namespace Corvus.Testing.AzureFunctions
                     startInfo.EnvironmentVariables[kvp.Key] = kvp.Value;
                 }
             }
+
+            // Force the logging level to debug to ensure we can pick up the message that tells us the function is
+            // ready to go.
+            startInfo.EnvironmentVariables["AzureFunctionsJobHost:logging:logLevel:default"] = "Debug";
 
             var processHandler = new FunctionOutputBufferHandler(startInfo);
             processHandler.Start();

--- a/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/Internal/FunctionOutputBufferHandler.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/Internal/FunctionOutputBufferHandler.cs
@@ -51,7 +51,8 @@ namespace Corvus.Testing.AzureFunctions.Internal
         protected override void OnStandardOutputLine(string line)
         {
             if (!this.jobHostStartedCompletionSource.Task.IsCompleted
-                && line?.Contains("Application started.") == true)
+                && (line?.Contains("Application started") == true
+                    || line?.Contains("Hosting started") == true))
             {
                 this.jobHostStartedCompletionSource.SetResult(true);
             }


### PR DESCRIPTION
The most recent version of Azure Functions Core Tools has changed the message it outputs to indicate that the application has started from `Application started` to `Hosting started`, so this PR adds support for that.

It also forces the log level for the function to debug to ensure that the messages are output.