### PR TITLE
Add cross-platform support

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -20,5 +20,5 @@ branches:
     - feature
     - support
     - hotfix
-next-version: "1.4"
+next-version: "1.5"
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ This provides a library of useful testing extensions, primarily focussed on Spec
 
 It is built for netstandard2.0.
 
+Starting with v1.5, the `Corvus.Testing.AzureFunctions` package and also supports netcoreapp3.1 or later. Note that the
+netstandard2.0 version of this package only works on Windows, because cross-platform support for
+killing process trees was not introduced until .NET Core 3.0 (and, oddly, was not added to
+netstandard2.1). And since .NET Core 3.0 is out of support, we support Linux on .NET Core 3.1 or later.
+
 The SpecFlow specific libraries contain additional bindings; to use these, you will need to add a `specflow.json` file to any project wishing to use them. Add entries to the `stepAssemblies` array for each of the Corvus libraries you need to use:
 
 ```json

--- a/Solutions/Corvus.Testing.AzureFunctions/Corvus.Testing.AzureFunctions.csproj
+++ b/Solutions/Corvus.Testing.AzureFunctions/Corvus.Testing.AzureFunctions.csproj
@@ -3,9 +3,9 @@
   <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netstandard2.0</TargetFrameworks>
     <Nullable>enable</Nullable>
-    <Copyright>Copyright (c) Endjin Limited 2020. All rights reserved.</Copyright>
+    <Copyright>Copyright (c) Endjin Limited 2020-2021. All rights reserved.</Copyright>
     <NoWarn>RCS1194</NoWarn>
   </PropertyGroup>
 
@@ -23,6 +23,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.16" />
-    <PackageReference Include="System.Management" Version="4.7.0" />
+
+    <PackageReference Include="System.Management" Version="4.7.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
   </ItemGroup>
 </Project>

--- a/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionProject.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionProject.cs
@@ -41,13 +41,19 @@ namespace Corvus.Testing.AzureFunctions
         {
             logger = logger ?? NullLogger.Instance;
 
-            string currentDirectory = Environment.CurrentDirectory.ToLowerInvariant();
-
-            string directoryExtension = @$"bin\release\{runtime}";
-            if (currentDirectory.Contains("debug"))
+            string currentDirectory = Environment.CurrentDirectory;
+            // Even though the dotnet Directory.Exists docs say that the path parameter is not case-sensitive
+            // Linix OS file systems are case sensitive so the folder names here need to be case sensitive
+            string outputFolder = string.Empty;
+            if(currentDirectory.Contains("Debug")) 
             {
-                directoryExtension = @$"bin\debug\{runtime}";
+                outputFolder = "Debug";
             }
+            else if (currentDirectory.Contains("Release"))
+            {
+                outputFolder = "Release";
+            }
+            string directoryExtension = Path.Combine("bin", outputFolder, runtime);
 
             logger.LogDebug("Working directory is {WorkingDirectory}", currentDirectory);
 

--- a/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionProject.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionProject.cs
@@ -43,7 +43,7 @@ namespace Corvus.Testing.AzureFunctions
 
             string currentDirectory = Environment.CurrentDirectory;
             // Even though the dotnet Directory.Exists docs say that the path parameter is not case-sensitive
-            // Linix OS file systems are case sensitive so the folder names here need to be case sensitive
+            // Linux OS file systems are case sensitive so the folder names here need to be case sensitive
             string outputFolder = string.Empty;
             if(currentDirectory.Contains("Debug")) 
             {

--- a/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionsController.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionsController.cs
@@ -168,7 +168,8 @@ StdErr: {StdErr}",
             string npmPrefix = await GetNpmPrefix().ConfigureAwait(false);
             string toolsFolder = Path.Combine(
                 npmPrefix,
-                @"node_modules\azure-functions-core-tools\bin");
+                "azure-functions-core-tools",
+                "bin");
 
             if (!Directory.Exists(toolsFolder))
             {
@@ -272,8 +273,8 @@ StdErr: {StdErr}",
             // Since Windows and Unix-like operating systems have quite different approaches here
             // we need OS-specific handling.
             (string command, string arguments) = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                ? ("cmd.exe", "/c npm prefix -g")
-                : ("npm", "prefix -g");
+                ? ("cmd.exe", "/c npm root -g")
+                : ("npm", "root -g");
             var processHandler = new ProcessOutputHandler(
                 new ProcessStartInfo(command, arguments)
                 {

--- a/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionsController.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionsController.cs
@@ -249,7 +249,7 @@ StdErr: {StdErr}",
         {
             // On Windows, the npm command is currently implemented as a .cmd file (the Windows
             // Command Prompt equivalent of a batch file). The Windows APIs for launching new
-            // processes do not recognized command files, batch files, or anything similar: they
+            // processes do not recognize command files, batch files, or anything similar: they
             // expect to be given a Win32 executable to launch. The ability to run a text file full
             // of script is, as far as Windows is concerned, the shell's business, not the OS's.
             // The upshot is that although typing "npm" at a command prompt will run npm, passing

--- a/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/Internal/FunctionOutputBufferHandler.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/Internal/FunctionOutputBufferHandler.cs
@@ -50,10 +50,11 @@ namespace Corvus.Testing.AzureFunctions.Internal
         /// <inheritdoc />
         protected override void OnStandardOutputLine(string line)
         {
+            // The functions host emits this the line before listing the function endpoints.
+            // It is a pretty safe bet that the service is ready once this appears.
+            const string outputIndicatingHostIsReady = "Functions:";
             if (!this.jobHostStartedCompletionSource.Task.IsCompleted
-            // this the line before emitting the function endpoints
-            // it is a pretty safe bet that the functions are available here
-                && (line?.Contains("Functions:") == true))
+                && (line?.Contains(outputIndicatingHostIsReady) == true))
             {
                 this.jobHostStartedCompletionSource.SetResult(true);
             }

--- a/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/Internal/FunctionOutputBufferHandler.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/Internal/FunctionOutputBufferHandler.cs
@@ -51,8 +51,9 @@ namespace Corvus.Testing.AzureFunctions.Internal
         protected override void OnStandardOutputLine(string line)
         {
             if (!this.jobHostStartedCompletionSource.Task.IsCompleted
-                && (line?.Contains("Application started") == true
-                    || line?.Contains("Hosting started") == true))
+            // this the line before emitting the function endpoints
+            // it is a pretty safe bet that the functions are available here
+                && (line?.Contains("Functions:") == true))
             {
                 this.jobHostStartedCompletionSource.SetResult(true);
             }

--- a/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/Internal/ProcessOutputHandler.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/Internal/ProcessOutputHandler.cs
@@ -191,7 +191,7 @@ namespace Corvus.Testing.AzureFunctions.Internal
             this.OnStandardErrorLine(line);
         }
 
-        private void OnProcessExit(object sender, EventArgs e)
+        private void OnProcessExit(object? sender, EventArgs e)
         {
             this.exitCodeCompletionSource.SetResult(this.Process.ExitCode);
             this.Process.OutputDataReceived -= this.OnOutputDataReceived;

--- a/docs/ReleaseNotes/Corvus.Testing.v1.md
+++ b/docs/ReleaseNotes/Corvus.Testing.v1.md
@@ -1,0 +1,12 @@
+# Release notes for Corvus.Testing v1.
+
+## v1.5
+
+New features:
+
+### Enable use on MacOS X and Linux
+
+To enable this, we have needed to add `netcoreapp3.1` as a target platform. This enables us to use
+the support for killing process trees. The `netstandard2.0` version continues to use the
+`System.Management` library to find child processes when shutting down the Functions host, meaning
+that it can only work on Windows.


### PR DESCRIPTION
Detect OS and select suitable launch mechanism for npm. Use cross-platform process tree kill on .NET Core 3.1 and later.