### PR TITLE
Revert build failure workaround

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,17 +23,10 @@ jobs:
     service_connection_github: $(Endjin_Service_Connection_GitHub)
     solution_to_build: $(Endjin_Solution_To_Build)
     postCustomEnvironmentVariables:
-      - task: NodeTool@0
-        displayName: 'Temporary downgrade of NPM to work around bug' # https://github.com/actions/runner-images/issues/7467#issuecomment-1518007292 - we can remove this once https://github.com/Azure/azure-functions-core-tools/pull/3338 drops, whenever azure-functions-core-tools >v4.0.5095 drops
-        inputs:
-          versionSpec: '18.15'
       - task: Npm@1
         displayName: 'Install Latest Azure Functions V4 Runtime'
         inputs:
           command: custom
           verbose: false
           customCommand: 'install -g azure-functions-core-tools@ --unsafe-perm true --verbose'
-      - powershell: |
-          gci -r C:\npm\prefix\node_modules\azure-functions-core-tools
-        displayName: 'Show Azure Functions V4 Runtime folder'
     netSdkVersion: '6.x'


### PR DESCRIPTION
The build started failing due to changes in the Azure Build agent, as reported at https://github.com/actions/runner-images/issues/7467

It appears that the underlying problem is a bug in the Node library being used to extract files from packages: https://github.com/ZJONSSON/node-unzipper/issues/271

The problem was that this corrupted some of the files being unpacked. This meant that when we tried to run `func` we got errors complaining about an invalid executable.

Although it looks like the underlying issue has not yet been fixed, the comment at https://github.com/actions/runner-images/issues/7467#issuecomment-1527456029 suggests that a new build agent image has been created that will not run into this problem. (Presumably they've done something to avoid the problematic package.) This means we should no longer need our workaround.