### PR TITLE
Fix intermittent errors during build and in VS Test Explorer

### DIFF
--- a/Solutions/Corvus.Testing.AzureFunctions.DemoFunction.InProcess/Corvus.Testing.AzureFunctions.DemoFunctions.InProcess.csproj
+++ b/Solutions/Corvus.Testing.AzureFunctions.DemoFunction.InProcess/Corvus.Testing.AzureFunctions.DemoFunctions.InProcess.csproj
@@ -11,6 +11,7 @@
 
   <PropertyGroup>
     <IsTestProject>false</IsTestProject>
+    <TestProject>false</TestProject>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Solutions/Corvus.Testing.AzureFunctions.DemoFunctions.Isolated/Corvus.Testing.AzureFunctions.DemoFunctions.Isolated.csproj
+++ b/Solutions/Corvus.Testing.AzureFunctions.DemoFunctions.Isolated/Corvus.Testing.AzureFunctions.DemoFunctions.Isolated.csproj
@@ -12,6 +12,7 @@
 
   <PropertyGroup>
     <IsTestProject>false</IsTestProject>
+    <TestProject>false</TestProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Solutions/Corvus.Testing.AzureFunctions.SpecFlow.NUnit/Corvus.Testing.AzureFunctions.SpecFlow.NUnit.csproj
+++ b/Solutions/Corvus.Testing.AzureFunctions.SpecFlow.NUnit/Corvus.Testing.AzureFunctions.SpecFlow.NUnit.csproj
@@ -7,7 +7,12 @@
 
   <PropertyGroup>
     <IsTestProject>false</IsTestProject>
+    <TestProject>false</TestProject>
   </PropertyGroup>
+  <ItemGroup>
+    <!-- This project takes depedency on nUnit that adds the TestContainer capability importing NUnit.props, but this is not a test project -->
+    <ProjectCapability Remove="TestContainer" />
+  </ItemGroup>
 
   <PropertyGroup>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/Solutions/Corvus.Testing.AzureFunctions.SpecFlow/Corvus.Testing.AzureFunctions.SpecFlow.csproj
+++ b/Solutions/Corvus.Testing.AzureFunctions.SpecFlow/Corvus.Testing.AzureFunctions.SpecFlow.csproj
@@ -10,7 +10,12 @@
 
   <PropertyGroup>
     <IsTestProject>false</IsTestProject>
+    <TestProject>false</TestProject>
   </PropertyGroup>
+  <ItemGroup>
+    <!-- This project takes depedency on nUnit that adds the TestContainer capability importing NUnit.props, but this is not a test project -->
+    <ProjectCapability Remove="TestContainer" />
+  </ItemGroup>
 
   <PropertyGroup>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/Solutions/Corvus.Testing.AzureFunctions.Xunit.Demo/FunctionPerTestFacts.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions.Xunit.Demo/FunctionPerTestFacts.cs
@@ -35,7 +35,7 @@ namespace Corvus.Testing.AzureFunctions.Xunit.Demo
                 .CreateLogger("Xunit Demo tests");
 
             this.function = new FunctionsController(logger);
-            this.Port = new Random().Next(50000, 60000);
+            this.Port = this.function.FindAvailableTcpPort(50000, 60000);
         }
 
         public int Port { get; }

--- a/Solutions/Corvus.Testing.AzureFunctions/Corvus.Testing.AzureFunctions.csproj
+++ b/Solutions/Corvus.Testing.AzureFunctions/Corvus.Testing.AzureFunctions.csproj
@@ -11,6 +11,7 @@
 
   <PropertyGroup>
     <IsTestProject>false</IsTestProject>
+    <TestProject>false</TestProject>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionsController.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionsController.cs
@@ -134,6 +134,34 @@ namespace Corvus.Testing.AzureFunctions
         }
 
         /// <summary>
+        /// Randomly selects a port that appears to be available for use.
+        /// </summary>
+        /// <param name="lowerBoundInclusive">
+        /// The lowest port number acceptable. Defaults to 50000.
+        /// </param>
+        /// <param name="upperBoundExclusive">
+        /// The port number above which no port will be selected. Defaults to 60000.
+        /// </param>
+        /// <returns>A port number that seems to be available.</returns>
+        public int FindAvailableTcpPort(int? lowerBoundInclusive, int? upperBoundExclusive)
+        {
+            int lb = lowerBoundInclusive ?? 50000;
+            int ub = upperBoundExclusive ?? 60000;
+
+            var portsInRangeInUse = IPGlobalProperties
+                .GetIPGlobalProperties()
+                .GetActiveTcpListeners()
+                .Select(e => e.Port)
+                .Where(p => p >= lb && p < ub)
+                .ToHashSet();
+
+            int availablePorts = ub - lb - portsInRangeInUse.Count;
+            int availablePortOffset = Random.Shared.Next(availablePorts);
+            int port = Enumerable.Range(lb, ub - lb).Where(p => !portsInRangeInUse.Contains(p)).ElementAt(availablePortOffset);
+            return port;
+        }
+
+        /// <summary>
         /// Provides access to the output.
         /// </summary>
         /// <returns>All output from the function host process.</returns>

--- a/Solutions/Corvus.Testing.SpecFlow.NUnit/Corvus.Testing.SpecFlow.NUnit.csproj
+++ b/Solutions/Corvus.Testing.SpecFlow.NUnit/Corvus.Testing.SpecFlow.NUnit.csproj
@@ -7,7 +7,12 @@
 
   <PropertyGroup>
     <IsTestProject>false</IsTestProject>
+    <TestProject>false</TestProject>
   </PropertyGroup>
+  <ItemGroup>
+    <!-- This project takes depedency on nUnit that adds the TestContainer capability importing NUnit.props, but this is not a test project -->
+    <ProjectCapability Remove="TestContainer" />
+  </ItemGroup>
 
   <PropertyGroup>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/Solutions/Corvus.Testing.SpecFlow/Corvus.Testing.SpecFlow.csproj
+++ b/Solutions/Corvus.Testing.SpecFlow/Corvus.Testing.SpecFlow.csproj
@@ -10,7 +10,12 @@
 
   <PropertyGroup>
     <IsTestProject>false</IsTestProject>
+    <TestProject>false</TestProject>
   </PropertyGroup>
+  <ItemGroup>
+    <!-- This project takes depedency on nUnit that adds the TestContainer capability importing NUnit.props, but this is not a test project -->
+    <ProjectCapability Remove="TestContainer" />
+  </ItemGroup>
 
   <PropertyGroup>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>


### PR DESCRIPTION
Resolves #429. Resolves #428.

* the XUnit demo's random port selection now avoids ports that are in use
* we have used all three ways of declaring that non-test projects really aren't test projects to prevent the 'testhost not found' errors the VS Test Explorer was sometimes reporting