### PR TITLE
Adjust nullability to align with IConfiguration

### DIFF
--- a/Solutions/Corvus.Testing.AzureFunctions.SpecFlow.Demo/AzureFunctionsTesting/DemoFunctionConfig.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions.SpecFlow.Demo/AzureFunctionsTesting/DemoFunctionConfig.cs
@@ -1,0 +1,32 @@
+﻿// <copyright file="DemoFunctionConfig.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Corvus.Testing.SpecFlow.Demo.AzureFunctionsTesting
+{
+    using System.Collections.Generic;
+
+    using Corvus.Testing.AzureFunctions;
+    using Corvus.Testing.AzureFunctions.SpecFlow;
+
+    using TechTalk.SpecFlow;
+
+    internal static class DemoFunctionConfig
+    {
+        public static void SetupTestConfig(SpecFlowContext context)
+        {
+            FunctionConfiguration functionConfiguration = FunctionsBindings.GetFunctionConfiguration(context);
+            var config = new Dictionary<string, string?>()
+            {
+                { "ResponseMessage", "Welcome, {name}" },
+
+                // IConfiguration's AsEnumerable includes null-valued entries for each
+                // section. Since the most common way to set up a function's configuration
+                // with this library is to pass that enumeration, we need to test this.
+                // See https://github.com/corvus-dotnet/Corvus.Testing/issues/368
+                { "Emulate:Null:Section:Entry", null },
+            };
+            functionConfiguration.CopyToEnvironmentVariables(config);
+        }
+    }
+}

--- a/Solutions/Corvus.Testing.AzureFunctions.SpecFlow.Demo/AzureFunctionsTesting/DemoFunctionPerFeatureHooks.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions.SpecFlow.Demo/AzureFunctionsTesting/DemoFunctionPerFeatureHooks.cs
@@ -45,18 +45,14 @@ namespace Corvus.Testing.SpecFlow.Demo.AzureFunctionsTesting
         [BeforeFeature("usingInProcessDemoFunctionPerFeatureWithAdditionalConfiguration")]
         public static Task StartInProcessFunctionWithAdditionalConfigurationAsync(FeatureContext featureContext)
         {
-            FunctionConfiguration functionConfiguration = FunctionsBindings.GetFunctionConfiguration(featureContext);
-            functionConfiguration.EnvironmentVariables.Add("ResponseMessage", "Welcome, {name}");
-
+            DemoFunctionConfig.SetupTestConfig(featureContext);
             return StartInProcessFunctionsAsync(featureContext);
         }
 
         [BeforeFeature("usingIsolatedDemoFunctionPerFeatureWithAdditionalConfiguration")]
         public static Task StartIsolatedFunctionWithAdditionalConfigurationAsync(FeatureContext featureContext)
         {
-            FunctionConfiguration functionConfiguration = FunctionsBindings.GetFunctionConfiguration(featureContext);
-            functionConfiguration.EnvironmentVariables.Add("ResponseMessage", "Welcome, {name}");
-
+            DemoFunctionConfig.SetupTestConfig(featureContext);
             return StartIsolatedFunctionsAsync(featureContext);
         }
 

--- a/Solutions/Corvus.Testing.AzureFunctions.SpecFlow.Demo/AzureFunctionsTesting/DemoFunctionPerScenarioHooks.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions.SpecFlow.Demo/AzureFunctionsTesting/DemoFunctionPerScenarioHooks.cs
@@ -43,18 +43,14 @@ namespace Corvus.Testing.SpecFlow.Demo.AzureFunctionsTesting
         [BeforeScenario("usingInProcessDemoFunctionPerScenarioWithAdditionalConfiguration")]
         public static Task StartInProcessFunctionWithAdditionalConfigurationAsync(ScenarioContext scenarioContext)
         {
-            FunctionConfiguration functionConfiguration = FunctionsBindings.GetFunctionConfiguration(scenarioContext);
-            functionConfiguration.EnvironmentVariables.Add("ResponseMessage", "Welcome, {name}");
-
+            DemoFunctionConfig.SetupTestConfig(scenarioContext);
             return StartIsolatedFunctionsAsync(scenarioContext);
         }
 
         [BeforeScenario("usingIsolatedDemoFunctionPerScenarioWithAdditionalConfiguration")]
         public static Task StartIsolatedFunctionWithAdditionalConfigurationAsync(ScenarioContext scenarioContext)
         {
-            FunctionConfiguration functionConfiguration = FunctionsBindings.GetFunctionConfiguration(scenarioContext);
-            functionConfiguration.EnvironmentVariables.Add("ResponseMessage", "Welcome, {name}");
-
+            DemoFunctionConfig.SetupTestConfig(scenarioContext);
             return StartIsolatedFunctionsAsync(scenarioContext);
         }
 

--- a/Solutions/Corvus.Testing.AzureFunctions.SpecFlow.Demo/Corvus.Testing.AzureFunctions.SpecFlow.Demo.csproj
+++ b/Solutions/Corvus.Testing.AzureFunctions.SpecFlow.Demo/Corvus.Testing.AzureFunctions.SpecFlow.Demo.csproj
@@ -57,6 +57,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Solutions/Corvus.Testing.AzureFunctions.SpecFlow.Demo/packages.lock.json
+++ b/Solutions/Corvus.Testing.AzureFunctions.SpecFlow.Demo/packages.lock.json
@@ -12,6 +12,16 @@
           "Microsoft.SourceLink.GitHub": "1.1.1"
         }
       },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Direct",
+        "requested": "[8.0.0, )",
+        "resolved": "8.0.0",
+        "contentHash": "0J/9YNXTMWSZP2p2+nvl8p71zpSwokZXZuJW+VjdErkegAnFdO1XlqtA62SJtgVYHdKu3uPxJHcMR/r35HwFBA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
       "Roslynator.Analyzers": {
         "type": "Direct",
         "requested": "[4.9.0, )",
@@ -90,21 +100,12 @@
           "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
         }
       },
-      "Microsoft.Extensions.Configuration": {
-        "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "tq2wXyh3fL17EMF2bXgRhU7JrbO3on93MRKYxzz4JzzvuGSA1l0W3GI9/tl8EO89TH+KWEymP7bcFway6z9fXg==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Primitives": "6.0.0"
-        }
-      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "qWzV9o+ZRWq+pGm+1dF+R7qTgTYoXvbyowRoBxQJGfqTpqDun2eteerjRQhq5PQ/14S+lqto3Ft4gYaRyl4rdQ==",
+        "resolved": "8.0.0",
+        "contentHash": "3lE/iLSutpgX1CC0NOW70FJoGARRHbyKmG7dc0klnUZ9Dd9hS6N/POPWhKhMLCEuNN5nXEY5agmlFtH562vqhQ==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "6.0.0"
+          "Microsoft.Extensions.Primitives": "8.0.0"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {
@@ -209,11 +210,8 @@
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "9+PnzmQFfEFNR9J2aDTfJGGupShHjOuGw4VUv+JB044biSHrnmCIMD+mJHmb2H7YryrfBEXDurxQ47gJZdCKNQ==",
-        "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        }
+        "resolved": "8.0.0",
+        "contentHash": "bXJEZrW9ny8vjMF1JV253WeLhpEVzFo1lyaZu1vQ4ZxWUlVvknZ/+ftFgVheLubb4eZPSwwxBeqS1JkCOjxd8g=="
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Transitive",

--- a/Solutions/Corvus.Testing.AzureFunctions.Xunit.Demo/FunctionPerTestFacts.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions.Xunit.Demo/FunctionPerTestFacts.cs
@@ -5,14 +5,17 @@
 // ReSharper disable ArrangeThisQualifier
 namespace Corvus.Testing.AzureFunctions.Xunit.Demo
 {
-    using System;
     using System.Net;
     using System.Reflection;
     using System.Threading.Tasks;
+
     using global::Xunit;
     using global::Xunit.Abstractions;
+
     using Microsoft.Extensions.Logging;
+
     using Serilog;
+
     using ILogger = Microsoft.Extensions.Logging.ILogger;
 
     public class FunctionPerTestFacts : DemoFunctionFacts, IAsyncLifetime
@@ -35,7 +38,7 @@ namespace Corvus.Testing.AzureFunctions.Xunit.Demo
                 .CreateLogger("Xunit Demo tests");
 
             this.function = new FunctionsController(logger);
-            this.Port = this.function.FindAvailableTcpPort(50000, 60000);
+            this.Port = PortFinder.FindAvailableTcpPort(50000, 60000);
         }
 
         public int Port { get; }

--- a/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionConfigurationExtensions.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionConfigurationExtensions.cs
@@ -17,13 +17,44 @@ namespace Corvus.Testing.AzureFunctions
         /// </summary>
         /// <param name="functionConfiguration">The function configuration to copy the values to.</param>
         /// <param name="values">The values to copy.</param>
+        /// <remarks>
+        /// <para>
+        /// It may seem odd that <paramref name="values"/> permits entries where the value is null.
+        /// This is because <c>IConfiguration</c>'s <c>AsEnumerable</c> extension method has always
+        /// supplied null-valued items to represent sections (but didn't make that clear until they
+        /// finally added nullabililty annotations). For example, given this:
+        /// </para>
+        /// <code><![CDATA[
+        /// {
+        ///   "Root": {
+        ///     "Middle": {
+        ///       "ExplicitNull": null,
+        ///       "Value": "v"
+        ///     }
+        ///   },
+        ///   "ExplicitNull": null
+        /// }
+        /// ]]></code>
+        /// <para>
+        /// the enumeration will include <c>Root</c> and <c>Root:Middle</c> entries that have a null
+        /// value. This wasn't obvious until <c>Microsoft.Extensions.Configuration.Abstractions</c> was
+        /// updated with nullability annotations.
+        /// </para>
+        /// <para>
+        /// The most common usage of this method is to pass that enumerable from an <c>IConfiguration</c>
+        /// which is why this tolerates nulls.
+        /// </para>
+        /// </remarks>
         public static void CopyToEnvironmentVariables(
             this FunctionConfiguration functionConfiguration,
-            IEnumerable<KeyValuePair<string, string>> values)
+            IEnumerable<KeyValuePair<string, string?>> values)
         {
-            foreach (KeyValuePair<string, string> item in values)
+            foreach (KeyValuePair<string, string?> item in values)
             {
-                functionConfiguration.EnvironmentVariables.Add(item.Key, item.Value);
+                if (item.Value is string value)
+                {
+                    functionConfiguration.EnvironmentVariables.Add(item.Key, value);
+                }
             }
         }
     }

--- a/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/PortFinder.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/PortFinder.cs
@@ -1,0 +1,58 @@
+﻿// <copyright file="PortFinder.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Corvus.Testing.AzureFunctions
+{
+    using System;
+    using System.Linq;
+    using System.Net.NetworkInformation;
+
+    /// <summary>
+    /// Enables tests to discover available ports.
+    /// </summary>
+    public static class PortFinder
+    {
+        /// <summary>
+        /// Randomly selects a port that appears to be available for use.
+        /// </summary>
+        /// <param name="lowerBoundInclusive">
+        /// The lowest port number acceptable. Defaults to 50000.
+        /// </param>
+        /// <param name="upperBoundExclusive">
+        /// The port number above which no port will be selected. Defaults to 60000.
+        /// </param>
+        /// <returns>A port number that seems to be available.</returns>
+        public static int FindAvailableTcpPort(int? lowerBoundInclusive, int? upperBoundExclusive)
+        {
+            int lb = lowerBoundInclusive ?? 50000;
+            int ub = upperBoundExclusive ?? 60000;
+
+            var portsInRangeInUse = IPGlobalProperties
+                .GetIPGlobalProperties()
+                .GetActiveTcpListeners()
+                .Select(e => e.Port)
+                .Where(p => p >= lb && p < ub)
+                .ToHashSet();
+
+            int availablePorts = ub - lb - portsInRangeInUse.Count;
+            int availablePortOffset = Random.Shared.Next(availablePorts);
+            int port = Enumerable.Range(lb, ub - lb).Where(p => !portsInRangeInUse.Contains(p)).ElementAt(availablePortOffset);
+            return port;
+        }
+
+        /// <summary>
+        /// Discovers whether something on the computer is already listening for incoming
+        /// requests on a particular port.
+        /// </summary>
+        /// <param name="port">The port number to check.</param>
+        /// <returns>True if the port is currently in use.</returns>
+        public static bool IsSomethingAlreadyListeningOn(int port)
+        {
+            return IPGlobalProperties
+                .GetIPGlobalProperties()
+                .GetActiveTcpListeners()
+                .Any(e => e.Port == port);
+        }
+    }
+}

--- a/docs/ReleaseNotes/Corvus.Testing.v3.md
+++ b/docs/ReleaseNotes/Corvus.Testing.v3.md
@@ -11,6 +11,7 @@ There are also breaking changes:
 
 * `Corvus.Testing.SpecFlow.NUnit` no longer references Moq; projects that were relying on this package to supply that dependency will now need to add their own reference if they want to continue using Moq
 * if a process is already listening on the port you want the hosted function to use, we now throw an exception instead of ploughing on
+* The `CopyToEnvironmentVariables` extension method for `FunctionConfiguration` now takes an enumerable of `KeyValuePair<string, string?>` - the value type is now a nullable string for reasons described in https://github.com/corvus-dotnet/Corvus.Testing/issues/368
 
 The reason for the change in behaviour when the port is in use is that the old behaviour often caused baffling test results. It was very easy to hit this case accidentally if you were debugging test, and then stopped debugging—terminating the debug session typically meant that the code that would have torn down the hosted test function never got a chance to run.
 


### PR DESCRIPTION
Also move port finder out into its own class, since it wasn't really anything to do with the FunctionsController. (Although this is a breaking change, the first two builds of v3.0 failed to push anything to NuGet, so nobody can be relying on the existing behaviour yet.)

Resolves #431