### PR TITLE
Support Function in nested directories

### DIFF
--- a/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionProject.cs
+++ b/Solutions/Corvus.Testing.AzureFunctions/Corvus/Testing/AzureFunctions/FunctionProject.cs
@@ -66,9 +66,10 @@ namespace Corvus.Testing.AzureFunctions
                     return Directory.EnumerateDirectories(parent).FirstOrDefault(fullFolderPath => Path.GetFileName(fullFolderPath).Equals(child, StringComparison.InvariantCultureIgnoreCase));
                 }
 
-                string? projectFolder = GetChildFolderCaseInsensitive(candidate.FullName, pathFragment);
+                // assume pathFragment is in the correct case
+                string? projectFolder = Path.Combine(candidate.FullName, pathFragment);
 
-                if (projectFolder is not null)
+                if (Directory.Exists(projectFolder))
                 {
                     string? binFolder = GetChildFolderCaseInsensitive(projectFolder, "bin");
                     if (binFolder is not null)


### PR DESCRIPTION
Fix #454

I opted for this simple solution instead of implementing a complex search by splitting the function path in segments